### PR TITLE
correct copy dir to not use rename and avoid cross-device link errors

### DIFF
--- a/go/common/dirs_and_files.go
+++ b/go/common/dirs_and_files.go
@@ -159,18 +159,21 @@ func Copy(src, dst string) error {
 		return err
 	}
 	if f.IsDir() {
-		tmpDir, err := ioutil.TempDir(os.TempDir(), "golang-copy")
+		tmpDir, err := ioutil.TempDir(os.TempDir(), "eris_copy")
 		if err != nil {
 			return err
 		}
 		if err := copyDir(src, tmpDir); err != nil {
 			return err
 		}
-		fi, err := os.Stat(src)
-		if err := os.MkdirAll(dst, fi.Mode()); err != nil {
+		if err := copyDir(tmpDir, dst); err != nil {
 			return err
 		}
-		return os.Rename(tmpDir, dst)
+		// fi, err := os.Stat(src)
+		// if err := os.MkdirAll(dst, fi.Mode()); err != nil {
+		// 	return err
+		// }
+		// return os.Rename(tmpDir, dst)
 	}
 	return copyFile(src, dst)
 }


### PR DESCRIPTION
cc @ebuchman 

copy was throwing on me. 