### PR TITLE
Correct Common Form markup for defined-term uses

### DIFF
--- a/apps/dual_integration/contracts/prose/template.commonform
+++ b/apps/dual_integration/contracts/prose/template.commonform
@@ -14,6 +14,6 @@
 
             \\ The contract was instantiated from a "factory" contract located at address: [Contract Factory Address] on the same blockchain network.
 
-            \\ {Seller} has the cryptographic keypair which results in the address of [Party A Address].
+            \\ <Seller> has the cryptographic keypair which results in the address of [Party A Address].
 
-            \\ {Buyer} has the cryptographic keypair which results in the address of [Party B Address].
+            \\ <Buyer> has the cryptographic keypair which results in the address of [Party B Address].


### PR DESCRIPTION
Tiny PR.  Trivia.

In current Common Form markup, `<Buyer>` is a use of a defined term, "Buyer".  `{Buyer}` is a cross-referenced to a form with the heading "Buyer".

You could also skip the markup format entirely, and just use a JSON file.  `npm i -g commonform-cli && commonform render -f native < document.cform`.